### PR TITLE
Use stderr for error messages

### DIFF
--- a/wifi_password/wifi_password.py
+++ b/wifi_password/wifi_password.py
@@ -19,7 +19,7 @@ def run_command(command):
 
 
 def print_error(text):
-    sys.stderr.write(f"ERROR: {text}")
+    sys.stderr.write(f"ERROR: {text}\n")
     sys.exit(1)
 
 

--- a/wifi_password/wifi_password.py
+++ b/wifi_password/wifi_password.py
@@ -19,7 +19,7 @@ def run_command(command):
 
 
 def print_error(text):
-    sys.stderr.write(f"ERROR: {text}\n")
+    print(f"ERROR: {text}", file=sys.stderr)
     sys.exit(1)
 
 

--- a/wifi_password/wifi_password.py
+++ b/wifi_password/wifi_password.py
@@ -19,7 +19,7 @@ def run_command(command):
 
 
 def print_error(text):
-    print(f"ERROR: {text}")
+    sys.stderr.write(f"ERROR: {text}")
     sys.exit(1)
 
 


### PR DESCRIPTION
Hello. 
I just wanted to propose this little change. Instead of using `stdin` to print error messages, to use `stderr`.
