### PR TITLE
fix line 71 IndexError at Windows

### DIFF
--- a/wifi_password/wifi_password.py
+++ b/wifi_password/wifi_password.py
@@ -63,8 +63,10 @@ def get_password(ssid):
 
     elif sys.platform == "win32":
         password = run_command(f"netsh wlan show profile name=\"{ssid}\" key=clear | findstr Key")
-        password = re.findall(r"Key Content\s+:\s(.*)", password)[0]
-
+        try:
+            password = re.findall(r"Key Content\s+:\s(.*)", password)[0]
+        except IndexError:
+            password = ""
     if password == "":
         print_error("Could not find password")
 

--- a/wifi_password/wifi_password.py
+++ b/wifi_password/wifi_password.py
@@ -94,6 +94,7 @@ def generate_qr_code(ssid, password, image=False):
 
 
 def main():
+    runcommand("chcp 437")
     parser = argparse.ArgumentParser(usage='%(prog)s [options]')
     parser.add_argument('--qrcode', "-q", action="store_true", default=False, help="Generate a QR code")
     parser.add_argument('--image', "-i", action="store_true", default=False, help="Create the QR code as image instead of showing it on the terminal (must be used along with --qrcode)")


### PR DESCRIPTION
I used this app
but I get this bug

```shell
Traceback (most recent call last):
  File "C:\Users\user\AppData\Roaming\Python\Python39\Scripts\wifi-password-script.py", line 33, in <module>
    sys.exit(load_entry_point('wifi-password==1.0.7', 'console_scripts', 'wifi-password')())
  File "C:\Users\user\AppData\Roaming\Python\Python39\site-packages\wifi_password\wifi_password.py", line 116, in main
    password = get_password(args.ssid)
  File "C:\Users\user\AppData\Roaming\Python\Python39\site-packages\wifi_password\wifi_password.py", line 76, in get_password
    password = re.findall(r"Key Content\s+:\s(.*)", password)[0]
IndexError: list index out of range
```

That's why I added this.
```python
def get_password(ssid):
    if ssid == "":
        print_error("SSID is not defined")

    if sys.platform == "darwin":
        password = run_command(f"security find-generic-password -l \"{ssid}\" -D 'AirPort network password' -w")
        password = password.replace("\n", "")

    elif sys.platform == "linux":
        # Check if the user is running with super user privilages
        if os.geteuid() != 0:
            password = run_command(f"sudo nmcli -s -g 802-11-wireless-security.psk connection show '{ssid}'")
        else:
            password = run_command(f"nmcli -s -g 802-11-wireless-security.psk connection show '{ssid}'")

        password = password.replace("\n", "")

    elif sys.platform == "win32":
        password = run_command(f"netsh wlan show profile name=\"{ssid}\" key=clear | findstr Key").replace("\r", "")
        try:
            password = re.findall(r"Key Content\s+:\s(.*)", password)[0]
        except IndexError:
            password = ""
    if password == "":
        print_error("Could not find password")

    return password
```