### PR TITLE
🐛 Fix potential bug with os not in english

### DIFF
--- a/wifi_password/wifi_password.py
+++ b/wifi_password/wifi_password.py
@@ -15,7 +15,9 @@ import colorama
 __version__ = "1.0.9"
 
 def run_command(command):
-    output, _ = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True).communicate()
+    env = os.environ.copy()
+    env["LANG"] = "C"
+    output, _ = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True, env=env).communicate()
     return output.decode("utf-8").rstrip('\r\n')
 
 


### PR DESCRIPTION
This is a repost of the https://github.com/sdushantha/wifi-password/pull/25 PR.

Hi,
After some tests with your tool, I discovered a little problem for some setups.

To detect SSID, it's using nmcli -t -f active,ssid dev wifi | egrep '^yes' | cut -d\: -f2.
The problem is that nmcli -t -f active,ssid dev wifi output depends of language. In english it will return SSID yes/no but for example in french it return SSID oui/non.

To fix that I'm forcing the language using LANG env variable.